### PR TITLE
Configure Logging and Add Option for Changing Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!--
+Types of changes:
+    Added for new features.
+    Changed for changes in existing functionality.
+    Deprecated for soon-to-be removed features.
+    Removed for now removed features.
+    Fixed for any bug fixes.
+    Security in case of vulnerabilities.
+-->
+
+## [Unreleased]
+
+### Added
+* This Changelog
+
+## [0.1.1] - 2024-11-03
+
+### Added
+* More content to README including a GIF with demo
+* MIT license
+
+### Changed
+* Refactor Python version parsing
+* Brighten color of "Released" column
+
+### Fixed
+* Fix Python version regex (allow alpha, beta, etc. versions)
+
+## [0.1.0] - 2024-11-02
+
+### Added
+* Basic CLI app that shows all Python releases with the active Python interpeter being highlighted
+
+
+[unreleased]: https://github.com/RafaelWO/pirel/compare/0.1.1...HEAD
+[0.1.1]: https://github.com/RafaelWO/pirel/compare/0.1.0...0.1.1
+[0.1.0]: https://github.com/RafaelWO/pirel/releases/tag/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Types of changes:
 
 ### Added
 * This Changelog
+* `typing-extensions` as dependency
+* Use rich for logging and add option to configure verbosity (`-v, --verbose`)
 
 ## [0.1.1] - 2024-11-03
 

--- a/pirel/cli.py
+++ b/pirel/cli.py
@@ -1,10 +1,17 @@
 import logging
+import sys
 
 import typer
 from rich.console import Console
 
+from .logging import setup_logging
 from .python_cli import get_active_python_info
 from .releases import PythonReleases
+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+else:
+    from typing import Annotated
 
 RICH_CONSOLE = Console()
 
@@ -13,8 +20,24 @@ app = typer.Typer()
 logger = logging.getLogger("pirel")
 
 
+def logging_callback(ctx: typer.Context, verbosity: int):
+    if ctx.resilient_parsing:
+        return
+
+    setup_logging(verbosity)
+    return verbosity
+
+
+VERBOSE_OPTION = Annotated[
+    int, typer.Option("--verbose", "-v", count=True, callback=logging_callback)
+]
+
+
 @app.command()
-def releases_table():
+def releases_table(
+    verbose: VERBOSE_OPTION = 0,
+):
+    """Shows all Python releases. Your active Python interpreter is highlighted."""
     py_info = get_active_python_info()
     py_version = py_info.version if py_info else None
 

--- a/pirel/logging.py
+++ b/pirel/logging.py
@@ -1,0 +1,22 @@
+import logging
+
+from rich.logging import RichHandler
+
+
+def setup_logging(verbosity: int = 0):
+    """Sets up the basic logging configuration.
+
+    Args:
+        verbosity (int): Configures the log level which defaults to WARNING.
+            A `verbosity` of `0` maps to WARNING, `1` -> INFO, and `2` (or more)
+            -> DEBUG. Defaults to `0`.
+    """
+    base_loglevel = logging.WARNING  # 30
+    # Calculate the log level based on verbosity, i.e. subtract intervals of 10
+    # from level WARNING (30).
+    loglevel = max(base_loglevel - (verbosity * 10), logging.DEBUG)
+    logging.basicConfig(
+        level=loglevel,
+        format="%(message)s",
+        handlers=[RichHandler(show_path=False, show_time=False)],
+    )

--- a/pirel/python_cli.py
+++ b/pirel/python_cli.py
@@ -70,6 +70,6 @@ def get_active_python_info() -> ActivePythonInfo | None:
         (py_cmd, "-c", "import sys; print(sys.executable)"), capture_output=True
     )
     path = path_out.stdout.decode().strip()
-    logger.info(f"Found interpreter at {path!r} (via {py_cmd!r})")
+    logger.info(f"Found active Python interpreter at {path!r} (command {py_cmd!r})")
 
     return ActivePythonInfo(cmd=py_cmd, path=path, version=version)

--- a/pirel/releases.py
+++ b/pirel/releases.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 import urllib.request
 from typing import Optional
 
@@ -10,6 +11,9 @@ from . import python_cli
 
 DATE_NOW = datetime.date.today()
 DATE_NOW_STR = str(DATE_NOW)
+RELEASE_CYCLE_URL = "https://raw.githubusercontent.com/python/devguide/refs/heads/main/include/release-cycle.json"
+
+logger = logging.getLogger("pirel")
 
 
 def parse_date(date_str: str) -> datetime.date:
@@ -76,9 +80,10 @@ class PythonRelease:
 
 class PythonReleases:
     def __init__(self) -> None:
-        with urllib.request.urlopen(
-            "https://raw.githubusercontent.com/python/devguide/refs/heads/main/include/release-cycle.json"
-        ) as f:
+        logger.debug(
+            f"Downloading Python release cycle data from URL {RELEASE_CYCLE_URL}"
+        )
+        with urllib.request.urlopen(RELEASE_CYCLE_URL) as f:
             self.releases_data = json.load(f)
 
         self.releases = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,17 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "pirel"
 version = "0.1.1"
 description = "The Python release cycle in your terminal"
+authors = [
+  {name = "Rafael Weingartner-Ortner", email = "weingartner.rafael@hotmail.com"}
+]
 readme = "README.md"
+license = {file = "LICENSE"}
+
 requires-python = ">=3.8"
 dependencies = [
   "rich>=13.9.2",
@@ -10,11 +19,12 @@ dependencies = [
   "typing-extensions>=4.12.2",
 ]
 
+keywords = ["cli", "python", "releases"]
 # Pypi classifiers: https://pypi.org/classifiers/
 classifiers = [
-  "Development Status :: 4 - Beta",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
-  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Software Development",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.8",
@@ -25,12 +35,14 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 
+[project.urls]
+Homepage = "https://github.com/RafaelWO/pirel"
+Repository = "https://github.com/RafaelWO/pirel"
+Issues  = "https://github.com/RafaelWO/pirel/issues"
+Changelog = "https://github.com/RafaelWO/pirel/blob/main/CHANGELOG.md"
+
 [project.scripts]
 pirel = "pirel.cli:app"
-
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.8"
 dependencies = [
   "rich>=13.9.2",
   "typer>=0.12.5",
+  "typing-extensions>=4.12.2",
 ]
 
 # Pypi classifiers: https://pypi.org/classifiers/

--- a/uv.lock
+++ b/uv.lock
@@ -161,6 +161,7 @@ source = { editable = "." }
 dependencies = [
     { name = "rich" },
     { name = "typer" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -173,6 +174,7 @@ dev = [
 requires-dist = [
     { name = "rich", specifier = ">=13.9.2" },
     { name = "typer", specifier = ">=0.12.5" },
+    { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
### Main Changes
* 🔊 Configure logging
  * Use rich's logging handler. The log level is configurable via the CLI option `--verbose, -v`.

### Other changes
* Since we want to use `typing.Annotated` for CLI options, `typing-extensions` is added as a dependency to make it work with Python 3.8.
* 📝 Add CHANGELOG
* 🔧 Restructure `pyproject.toml` and add more fields