### PR TITLE
Exit with Error if EOL (check) and Use Global Options in Main Callback Only

### DIFF
--- a/pirel/cli.py
+++ b/pirel/cli.py
@@ -78,6 +78,7 @@ def list_releases() -> None:
 def check_release() -> None:
     """Shows release information about your active Python interpreter.
 
+    If the active version is end-of-life, the program exits with code 1.
     If no active Python interpreter is found, the program exits with code 2.
     """
     py_info = get_active_python_info()
@@ -91,6 +92,9 @@ def check_release() -> None:
     active_release = releases[py_info.version.as_release]
 
     RICH_CONSOLE.print(f"\n{active_release}", highlight=False)
+
+    if active_release.is_eol:
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/pirel/cli.py
+++ b/pirel/cli.py
@@ -50,15 +50,16 @@ def print_releases() -> None:
     RICH_CONSOLE.print(releases.to_table(py_version), new_line_start=True)
 
 
-# This callback is a hack to "redirect" to the `list` command if no command is passed.
-# This will be removed in a future version.
 @app.callback(invoke_without_command=True)
-def redirect_no_command_to_list(
+def main(
     ctx: typer.Context,
-    verbose: Annotated[int, typer.Option("--verbose", "-v", count=True)] = 0,
+    verbose: VERBOSE_OPTION = 0,
 ) -> None:
+    """The Python release cycle in your terminal."""
     if not ctx.invoked_subcommand:
-        setup_logging(verbose)
+        # This hack is for backwards compatibility that "redirects" to the `list`
+        # command if no command is passed.
+        # This will be removed in a future version.
         logger.warning(
             "Invoking `pirel` without a command is deprecated"
             " and will be removed in a future version."
@@ -68,20 +69,22 @@ def redirect_no_command_to_list(
 
 
 @app.command("list")
-def list_releases(verbose: VERBOSE_OPTION = 0) -> None:
+def list_releases() -> None:
     """Lists all Python releases in a table. Your active Python interpreter is highlighted."""
     print_releases()
 
 
 @app.command("check")
-def check_release(verbose: VERBOSE_OPTION = 0) -> None:
+def check_release() -> None:
     """Shows release information about your active Python interpreter.
 
     If no active Python interpreter is found, the program exits with code 2.
     """
     py_info = get_active_python_info()
     if not py_info:
-        logger.error("Could not find active Python interpreter in PATH.")
+        logger.error(
+            "Could not find active Python interpreter in PATH. Try to run with `--verbose`"
+        )
         raise typer.Exit(code=2)
 
     releases = load_releases()

--- a/pirel/releases.py
+++ b/pirel/releases.py
@@ -83,7 +83,7 @@ def wrap_style(text: str, style: str) -> str:
 class PythonRelease:
     def __init__(self, version: str, data: dict[str, Any]):
         self._version = version
-        self._status = data["status"]
+        self._status: str = data["status"]
         self._released = parse_date(data["first_release"])
         self._end_of_life = parse_date(data["end_of_life"])
 
@@ -116,6 +116,10 @@ class PythonRelease:
         font_style = date_style(self._end_of_life)
         color = eol_color(self._end_of_life)
         return wrap_style(str(self._end_of_life), style=f"{font_style} {color}")
+
+    @property
+    def is_eol(self) -> bool:
+        return self._status == "end-of-life"
 
 
 class PythonReleases:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,7 +80,12 @@ def releases_table():
 
 @pytest.mark.parametrize("args, log_count", [(None, 2), ("list", 0)])
 def test_pirel_list(
-    args, log_count, mock_rich_no_wrap, mock_release_cycle_file, releases_table, caplog
+    args,
+    log_count,
+    mock_rich_no_wrap,
+    mock_release_cycle_file,
+    releases_table,
+    caplog,
 ):
     caplog.set_level(logging.WARNING)
 
@@ -105,10 +110,13 @@ def test_pirel_list(
 
 def test_pirel_check(mock_rich_no_wrap, mock_release_cycle_file):
     pyver = PythonVersion.this()
+    expected_exit_code = (
+        1 if "end-of-life" in PYVER_TO_CHECK_OUTPUT[pyver.as_release] else 0
+    )
 
     # Call CLI
     result = runner.invoke(app, "check")
-    assert result.exit_code == 0, result.stdout
+    assert result.exit_code == expected_exit_code, result.stdout
 
     # Check output
     output = result.stdout.strip()


### PR DESCRIPTION
* ♻️ Use global verbose option only in main callback
  * Update docstrings
  * Improve error message
* ✨ command check: exit with code 1 if version is EOL