### PR TITLE
✨ Add guessing feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,4 @@ jobs:
       run: uv run mypy pirel/
 
     - name: Run tests
-      run: uv run pytest tests/
+      run: uv run pytest -vv tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,26 @@ Types of changes:
 
 ## [Unreleased]
 
+### Added
+* Add global option `--version` (#10)
+* Create cache of release cycle data and add option `--no-cache` to clear cache (#12)
+* Add subcommand `guess` which allows users to test their knowledge about Python releases
+by answering questions based on the release cycle data (#13)
+
+### Changed
+* Subcommand `check` exits with code 1 if the version is end-of-life (#9)
+* Use global verbose option only in main callback (#9)
+  * I.e. `pirel --verbose check` works but `pirel check --verbose` does not
+
+### Internal
+* CI: Run publish workflow only if test suite succeeds (#11)
+
 ## [0.2.1] - 2024-12-20
 
-## Fixed
+### Fixed
 * Fix typo in end-of-life status message (#6)
 
-## Internal
+### Internal
 * Restructure and reformat README (#6)
 * Add mypy to test suite (#7)
 

--- a/README.md
+++ b/README.md
@@ -29,37 +29,75 @@ pip install pirel
 ```
 
 
-## Usage
+## CLI Docs
+**Usage**:
 
-### Check Active Python Version
+```console
+$ pirel [OPTIONS] COMMAND [ARGS]...
 ```
-Usage: pirel check [OPTIONS]
+
+**Options**:
+
+* `--no-cache`: Clear cache before running
+* `-v, --verbose`: Enable verbose logging; can be supplied multiple times to increase verbosity. [default: 0]
+* `--version`: Dispay the version of pirel
+* `--install-completion`: Install completion for the current shell.
+* `--show-completion`: Show completion for the current shell, to copy it or customize the installation.
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `check`: Shows release information about your active Python interpreter.
+* `guess`: Test your knowledge by answering a question regarding Python releases.
+* `list`: Lists all Python releases in a table.
+
+### `pirel check`
 
 Shows release information about your active Python interpreter.
+
+If the active version is end-of-life, the program exits with code 1.
 If no active Python interpreter is found, the program exits with code 2.
 
-╭─ Options ───────────────────────────────────────────────────────────────────────────────╮
-│ --verbose  -v      INTEGER  Enable verbose logging; can be supplied multiple times to   │
-│                             increase verbosity.                                         │
-│                             [default: 0]                                                │
-│ --help                      Show this message and exit.                                 │
-╰─────────────────────────────────────────────────────────────────────────────────────────╯
+**Usage**:
+
+```console
+$ pirel check [OPTIONS]
 ```
 
+**Options**:
 
-### List Python Releases
+* `--help`: Show this message and exit.
+
+### `pirel guess`
+
+Test your knowledge by answering a question regarding Python releases.
+
+For example, "When was Python 3.9 released?" or "Who was the release manager for
+Python 3.6?".
+
+**Usage**:
+
+```console
+$ pirel guess [OPTIONS]
 ```
-Usage: pirel list [OPTIONS]
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+### `pirel list`
 
 Lists all Python releases in a table. Your active Python interpreter is highlighted.
 
-╭─ Options ───────────────────────────────────────────────────────────────────────────────╮
-│ --verbose  -v      INTEGER  Enable verbose logging; can be supplied multiple times to   │
-│                             increase verbosity.                                         │
-│                             [default: 0]                                                │
-│ --help                      Show this message and exit.                                 │
-╰─────────────────────────────────────────────────────────────────────────────────────────╯
+**Usage**:
+
+```console
+$ pirel list [OPTIONS]
 ```
+
+**Options**:
+
+* `--help`: Show this message and exit.
 
 > [!NOTE]
 > You can still invoke `pirel` without a subcommand and you will get a table of all Python releases.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@
 
 
 ## Installation
-It is recommended to install Pirel as a globally available CLI tool via `pipx` (or `uv tool`, etc.).
+It is recommended to install Pirel as a globally available CLI tool via `uv` (or `pipx`, etc.).
 This way you Pirel will show you the status of your active Python interpreter.
+
+```
+uv tool install pirel
+```
+
+OR
 
 ```
 pipx install pirel
@@ -27,6 +33,9 @@ You can also install Pirel into a specific virtual environment.
 ```
 pip install pirel
 ```
+
+Not that in this case Pirel will only have access to the Python interpreter of this
+very virtual environment.
 
 
 ## CLI Docs

--- a/pirel/_guess.py
+++ b/pirel/_guess.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import abc
+import csv
+import datetime
+import inspect
+import random
+from typing import Callable, Iterable, Optional, TextIO
+
+import platformdirs
+from rich.console import Console
+from rich.prompt import DefaultType, Prompt
+from rich.text import Text
+
+from .releases import PythonRelease
+
+STATS_DIR = platformdirs.user_data_path("pirel")
+STATS_FILENAME = "guess_stats.csv"
+STATS_FIELDNAMES = ["time", "question_cls", "target_release", "score"]
+
+
+class PirelPrompt(Prompt):
+    """A customized `rich.prompt.Prompt` that needs choices and returns a str.
+
+    The choices are rendered as possible answers for a question prefixed by a), b), etc.
+
+    Example:
+        >>> prompt = PirelPrompt("What year do we have?", choices=["2020", "2024", "2022"])
+        >>> answer = prompt()
+        What year do we have?
+         a) 2020
+         b) 2024
+         c) 2022
+        >
+    """
+
+    prompt_suffix = "\n> "
+    illegal_choice_message = "[prompt.invalid.choice]Please select one of the available options or indices (a, b, etc.)"
+    choices: list[str]
+    stream: Optional[TextIO] = None  # To be mocked during tests
+
+    def __init__(
+        self,
+        prompt: str,
+        *,
+        choices: list[str],
+        console: Optional[Console] = None,
+        password: bool = False,
+        case_sensitive: bool = True,
+        show_default: bool = True,
+    ):
+        super().__init__(
+            prompt,
+            choices=choices,
+            show_choices=True,
+            console=console,
+            password=password,
+            case_sensitive=case_sensitive,
+            show_default=show_default,
+        )
+        self.choice_enum = "abcdefgh"[: len(self.choices)]
+
+    def make_prompt(self, default: DefaultType) -> Text:
+        """Make prompt text.
+
+        Args:
+            default (DefaultType): Default value.
+
+        Returns:
+            Text: Text to display in prompt.
+        """
+        prompt = self.prompt.copy()
+        prompt.end = ""
+
+        if self.show_choices and self.choices:
+            # We want to list the choices as lines
+            choices = "\n".join(
+                f" {i}) {c}" for i, c in zip(self.choice_enum, self.choices)
+            )
+
+            prompt.append("\n")
+            prompt.append(choices, "prompt.choices")
+
+        if (
+            default != ...
+            and self.show_default
+            and isinstance(default, (str, self.response_type))
+        ):
+            prompt.append(" ")
+            _default = self.render_default(default)
+            prompt.append(_default)
+
+        prompt.append(self.prompt_suffix)
+
+        return prompt
+
+    def check_choice(self, value: str) -> bool:
+        """Check value is in the list of valid choices.
+
+        Args:
+            value (str): Value entered by user.
+
+        Returns:
+            bool: True if choice was valid, otherwise False.
+        """
+        return value in self.choice_enum or super().check_choice(value)
+
+    def process_response(self, value: str) -> str:
+        """Process response from user, convert to prompt type.
+
+        Args:
+            value (str): String typed by user.
+
+        Raises:
+            InvalidResponse: If ``value`` is invalid.
+
+        Returns:
+            str: The value to be returned from ask method.
+        """
+        if value in self.choice_enum:
+            return self.choices[self.choice_enum.index(value)]
+        else:
+            return super().process_response(value)
+
+
+class Question(abc.ABC):
+    """Base class for a question regarding Python releases."""
+
+    question: str
+    target_release: PythonRelease
+    get_target_field: Callable[[PythonRelease], str]
+
+    def __init__(self, releases: list[PythonRelease], console: Console):
+        if not hasattr(self, "target_release"):
+            self.target_release = random.choice(releases)
+        self.releases = releases
+        self.console = console
+        self.choices = self.build_choices()
+
+    @property
+    def correct_answer(self) -> str:
+        """Returns the correct answer as a string by calling `get_target_field` on the
+        target release object.
+
+        Returns:
+            str: The answer for the question.
+        """
+        return self.get_target_field(self.target_release)
+
+    def generate_incorrect_choices(
+        self,
+        *predicates: Callable[[PythonRelease], bool],
+        k: int = 3,
+        remove_duplicates: bool = False,
+    ) -> list[PythonRelease]:
+        """Generates random choices of `PythonRelease` objects excluding the target
+        release (i.e. the answer).
+
+        Args:
+            *predicates (Callable[[PythonRelease], bool]): A set of predicates to apply
+                as filters for the releases.
+            k (int, optional): The number of choices to return. Defaults to 3.
+
+        Returns:
+            list[PythonRelease]: A list of releases to serve as incorrect answers.
+        """
+        # Shuffle releases to have a random set of choices
+        random.shuffle(self.releases)
+
+        candidates: Iterable[PythonRelease] = filter(
+            lambda x: x != self.target_release, self.releases
+        )
+        for pred in predicates:
+            candidates = filter(pred, candidates)
+
+        if remove_duplicates:
+            candidates = {
+                self.get_target_field(rel): rel for rel in candidates
+            }.values()
+        return list(candidates)[:k]
+
+    def format_question(self) -> str:
+        """Hook to format the question."""
+        return self.question
+
+    def incorrect_choices(self) -> list[PythonRelease]:
+        """Hook to create a set of incorrect choices."""
+        return self.generate_incorrect_choices()
+
+    def build_choices(self) -> list[str]:
+        """Builds all choices for a question by combining the target release/answer and
+        the incorrect ones.
+
+        Returns:
+            list[str]: A list of choices.
+        """
+
+        choices = list(
+            map(self.get_target_field, [self.target_release, *self.incorrect_choices()])
+        )
+        # Shuffle so that correct choice is not first item
+        random.shuffle(choices)
+        return choices
+
+    def ask(self) -> bool:
+        """Construct the prompt for the question, prompt the user, and return the
+        result.
+
+        Returns:
+            bool: `True` if the answer was correct, else `False`.
+        """
+        prompt = PirelPrompt(
+            self.format_question(),
+            choices=self.choices,
+            console=self.console,
+        )
+        answer = prompt(stream=PirelPrompt.stream)
+        if answer == self.correct_answer:
+            self.console.print(f"[prompt.choices]{answer}[/] is [green]correct![/]")
+            return True
+        else:
+            self.console.print(
+                f"[prompt.choices]{answer}[/] is [red]wrong![/] (Correct answer: [prompt.choices]{self.correct_answer}[/])"
+            )
+            return False
+
+
+class LatestVersionQuestion(Question):
+    question: str = "What is the latest stable version of Python?"
+    __doc__ = question
+
+    def __init__(self, releases: list[PythonRelease], console: Console):
+        self.target_release = max(filter(lambda x: x._status == "bugfix", releases))
+        self.get_target_field = lambda x: x.version
+        super().__init__(releases, console)
+
+    def incorrect_choices(self) -> list[PythonRelease]:
+        return self.generate_incorrect_choices(lambda x: x.version.startswith("3"))
+
+
+class VersionDateQuestion(Question):
+    question: str = "When was Python {version} released?"
+    __doc__ = question
+
+    def __init__(self, releases: list[PythonRelease], console: Console):
+        self.target_release = random.choice(releases)
+        self.get_target_field = lambda x: x._released.isoformat()
+        super().__init__(releases, console)
+
+    def format_question(self) -> str:
+        return self.question.format(version=self.target_release.version)
+
+
+class DateVersionQuestion(Question):
+    question: str = "Which version of Python was released on {release_date}?"
+    __doc__ = question
+
+    def __init__(self, releases: list[PythonRelease], console: Console):
+        self.target_release = random.choice(releases)
+        self.get_target_field = lambda x: x.version
+        super().__init__(releases, console)
+
+    def format_question(self) -> str:
+        return self.question.format(release_date=self.target_release._released)
+
+
+class ReleaseManagerVersionQuestion(Question):
+    question: str = "Who was the release manager for Python {version}?"
+    __doc__ = question
+
+    def __init__(self, releases: list[PythonRelease], console: Console):
+        self.get_target_field = lambda x: x._release_manager
+        super().__init__(releases, console)
+
+    def format_question(self) -> str:
+        return self.question.format(version=self.target_release._version)
+
+    def incorrect_choices(self) -> list[PythonRelease]:
+        return self.generate_incorrect_choices(remove_duplicates=True)
+
+
+def store_question_score(question: Question, score: int) -> None:
+    """Save question score to user data."""
+    if not STATS_DIR.exists():
+        STATS_DIR.mkdir(parents=True)
+
+    stats_file = STATS_DIR / STATS_FILENAME
+    with stats_file.open("a", newline="") as file:
+        writer = csv.DictWriter(
+            file, fieldnames=STATS_FIELDNAMES, quoting=csv.QUOTE_NONNUMERIC
+        )
+        if file.tell() == 0:
+            writer.writeheader()
+        writer.writerow(
+            {
+                "time": datetime.datetime.now().isoformat(),
+                "question_cls": question.__class__.__name__,
+                "target_release": question.target_release.version,
+                "score": score,
+            }
+        )
+
+
+def get_random_question(releases: list[PythonRelease], console: Console) -> Question:
+    """Randomly picks one of the available questions.
+
+    Args:
+        releases (list[PythonRelease]): A list of Python release objects.
+        console (Console): A rich Console instance.
+
+    Returns:
+        type[Question]: A class of type `Question`.
+    """
+    question_cls = random.choice(
+        [
+            var
+            for var in globals().values()
+            if inspect.isclass(var) and issubclass(var, Question) and var != Question
+        ]
+    )
+    return question_cls(releases, console)
+
+
+def ask_random_question(releases: list[PythonRelease], console: Console) -> None:
+    """Prompt the user with one of the available questions and store the answer in user
+    data.
+
+    Args:
+        releases (list[PythonRelease]): A list of Python release objects.
+        console (Console): A rich Console instance.
+    """
+    question = get_random_question(releases, console)
+    score = int(question.ask())
+    store_question_score(question, score)

--- a/pirel/_utils.py
+++ b/pirel/_utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import abc
+
+
+class VersionLike(abc.ABC):
+    """Abstract class for objects that hold a version (`tuple` of `int`s) and
+    should be comparible based on their version.
+    """
+
+    @property
+    @abc.abstractmethod
+    def version_tuple(self) -> tuple[int, ...]:
+        pass
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, VersionLike):
+            return NotImplemented
+        return self.version_tuple == other.version_tuple
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, VersionLike):
+            return NotImplemented
+        return self.version_tuple < other.version_tuple
+
+    def __le__(self, other: object) -> bool:
+        if not isinstance(other, VersionLike):
+            return NotImplemented
+        return self.version_tuple <= other.version_tuple
+
+    def __gt__(self, other: object) -> bool:
+        if not isinstance(other, VersionLike):
+            return NotImplemented
+        return self.version_tuple > other.version_tuple
+
+    def __ge__(self, other: object) -> bool:
+        if not isinstance(other, VersionLike):
+            return NotImplemented
+        return self.version_tuple >= other.version_tuple

--- a/pirel/cli.py
+++ b/pirel/cli.py
@@ -7,7 +7,7 @@ from rich.console import Console
 
 import pirel
 
-from . import _cache
+from . import _cache, _guess
 from .logging import setup_logging
 from .python_cli import get_active_python_info
 from .releases import load_releases
@@ -120,6 +120,18 @@ def check_release() -> None:
 
     if active_release.is_eol:
         raise typer.Exit(code=1)
+
+
+@app.command("guess")
+def guess_release_question() -> None:
+    """Test your knowledge by answering a question regarding Python releases.
+
+    For example, "When was Python 3.9 released?" or "Who was the release manager for
+    Python 3.6?".
+    """
+    releases = load_releases()
+
+    _guess.ask_random_question(releases.as_list, RICH_CONSOLE)
 
 
 if __name__ == "__main__":

--- a/pirel/cli.py
+++ b/pirel/cli.py
@@ -17,7 +17,7 @@ if sys.version_info < (3, 9):
 else:
     from typing import Annotated
 
-RICH_CONSOLE = Console()
+RICH_CONSOLE = Console(highlight=False)
 
 
 app = typer.Typer(name="pirel")
@@ -116,7 +116,7 @@ def check_release() -> None:
     releases = load_releases()
     active_release = releases[py_info.version.as_release]
 
-    RICH_CONSOLE.print(f"\n{active_release}", highlight=False)
+    RICH_CONSOLE.print(f"\n{active_release}")
 
     if active_release.is_eol:
         raise typer.Exit(code=1)

--- a/pirel/python_cli.py
+++ b/pirel/python_cli.py
@@ -6,12 +6,14 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
+from . import _utils
+
 PYTHON_VERSION_RE = re.compile(r"Python ([23])\.(\d+)\.(\d+)")
 logger = logging.getLogger("pirel")
 
 
 @dataclass(frozen=True)
-class PythonVersion:
+class PythonVersion(_utils.VersionLike):
     major: int
     minor: int
     patch: int
@@ -33,6 +35,10 @@ class PythonVersion:
     @property
     def as_release(self) -> str:
         return f"{self.major}.{self.minor}"
+
+    @property
+    def version_tuple(self) -> tuple[int, int, int]:
+        return (self.major, self.minor, self.patch)
 
     def __str__(self) -> str:
         return f"{self.major}.{self.minor}.{self.patch}"

--- a/pirel/releases.py
+++ b/pirel/releases.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import functools
 import json
 import logging
 import urllib.error
@@ -88,6 +89,7 @@ class PythonRelease(_utils.VersionLike):
         self._status: str = data["status"]
         self._released = parse_date(data["first_release"])
         self._end_of_life = parse_date(data["end_of_life"])
+        self._release_manager = data["release_manager"]
 
     def __str__(self) -> str:
         status_info = STATUS_TO_TEXT[self._status].format(
@@ -137,6 +139,10 @@ class PythonReleases:
 
     def __getitem__(self, version: str) -> PythonRelease:
         return self.releases[version]
+
+    @functools.cached_property
+    def as_list(self) -> list[PythonRelease]:
+        return list(self.releases.values())
 
     def to_table(
         self, active_python_version: Optional[python_cli.PythonVersion] = None

--- a/pirel/releases.py
+++ b/pirel/releases.py
@@ -11,7 +11,7 @@ import humanize
 import typer
 from rich.table import Table
 
-from . import _cache, python_cli
+from . import _cache, _utils, python_cli
 
 DATE_NOW = datetime.date.today()
 RELEASE_CYCLE_URL = "https://raw.githubusercontent.com/python/devguide/refs/heads/main/include/release-cycle.json"
@@ -82,7 +82,7 @@ def wrap_style(text: str, style: str) -> str:
     return f"[{style.strip()}]{text}[/{style.strip()}]"
 
 
-class PythonRelease:
+class PythonRelease(_utils.VersionLike):
     def __init__(self, version: str, data: dict[str, Any]):
         self._version = version
         self._status: str = data["status"]
@@ -104,6 +104,10 @@ class PythonRelease:
     @property
     def version(self) -> str:
         return self._version
+
+    @property
+    def version_tuple(self) -> tuple[int, ...]:
+        return tuple(map(int, self._version.split(".")))
 
     @property
     def status(self) -> str:


### PR DESCRIPTION
The new `guess` subcommand enables users to test their knowledge about Python releases by answering questions based on the release cycle data. For example, when was which release published or who was the release manager. The answers are stored in a CSV file in the user data directory.

### Main Changes
* ✨ Make versions compatible
  * Implement comparison functions for version objects `PythonVersion` and `PythonRelease`.
* ✨ Add guessing feature via subcommand `guess`
  * Add tests for `guess` are added as well.

### Other Changes
* 🔧 Disable highlight in rich console globally
* 👷 Increase verbosity of pytest in CI
* 📝 Update unreleased section in CHANGELOG
* 📝 Update CLI docs in README
  * Use typer utils to generate CLI docs via `uv run -m typer pirel.cli utils docs` (with small changes)
* 📝 Update installation guide in README
  * Mention uv as first option for install
  * Add note regarding installing in virtual environment