### PR TITLE
Update release-cycle.json URL

### DIFF
--- a/pirel/releases.py
+++ b/pirel/releases.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from . import _cache, _utils, python_cli
 
 DATE_NOW = datetime.date.today()
-RELEASE_CYCLE_URL = "https://raw.githubusercontent.com/python/devguide/refs/heads/main/include/release-cycle.json"
+RELEASE_CYCLE_URL = "https://peps.python.org/api/release-cycle.json"
 
 STATUS_TO_TEXT = {
     "feature": "is [bold]not released yet[/bold] and still accepts new features",

--- a/pirel/releases.py
+++ b/pirel/releases.py
@@ -62,7 +62,7 @@ def status_style(status: str) -> str:
     elif status == "feature":
         return "magenta"
     else:
-        raise ValueError(f"Unkown status {status}")
+        raise ValueError(f"Unknown status {status}")
 
 
 def eol_color(eol: datetime.date) -> str:


### PR DESCRIPTION
This file is now generated and published from the PEPs repo (https://github.com/python/peps/pull/4331) and will be removed from the devguide soon (https://github.com/python/devguide/pull/1685).